### PR TITLE
chart: add ingress labels to values

### DIFF
--- a/chart/kubeapps-hub/templates/ingress.yaml
+++ b/chart/kubeapps-hub/templates/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- range $key, $value := .Values.ingress.labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   rules:
   {{- range .Values.ingress.hosts }}

--- a/chart/kubeapps-hub/values.yaml
+++ b/chart/kubeapps-hub/values.yaml
@@ -123,6 +123,12 @@ ingress:
     ## Traefik ingress controller
     # traefik.frontend.rule.type: PathPrefixStrip
     # kubernetes.io/ingress.class: traefik
+  
+  ## Ingress labels
+  #
+  labels: {}
+    ## e.g. for PalmStoneGames kube-cert-manager
+    # stable.k8s.psg.io/kcm.class: default
 
   ## Ingress TLS configuration
   ## Secrets must be manually created in the namespace


### PR DESCRIPTION
We need this to add the kube-cert-manager label https://github.com/PalmStoneGames/kube-cert-manager/blob/master/docs/ingress.md