### PR TITLE
fix showRepoInstructions condition

### DIFF
--- a/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -1,6 +1,6 @@
 <app-panel class="chart-details-usage" [border]=true>
   <h1>Install</h1>
-  <div *ngIf=!showRepoInstructions class="chart-details-usage__repository">
+  <div *ngIf="showRepoInstructions" class="chart-details-usage__repository">
     <label for="repoAddInstructions">Add {{ chart.attributes.repo.name }} repository</label>
     <div class="input-group">
       <input id="repoAddInstructions" readonly [value]=repoAddInstructions />


### PR DESCRIPTION
previously this condition was inverted and so only showing the
instructions for the stable repo. This commit fixes the condition to ensure we
only omit instructions for the stable repo.