### PR TITLE
Verify https://hub.kubeapps.com ownership for Google Search Console

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta name="fragment" content="!">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Discover & launch great Kubernetes-ready apps">
+  <meta name="google-site-verification" content="5bhjc16z4tg3DvpnxOrS4iBCVbzuld8hS2lVMLdlRig" />
   <!-- favicons -->
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/assets/images/apple-touch-icon-57x57.png" />
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/images/apple-touch-icon-114x114.png" />


### PR DESCRIPTION
Meta tag seems like the simplest way to do this for now.

This is in order to investigate improvements to hub seo: 

> Search Console tools and reports help you measure your site's Search traffic and performance, fix issues, and make your site shine in Google Search results

https://search.google.com/search-console/about