### PR TITLE
Open Kubeapps get started link in a new window

### DIFF
--- a/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -35,7 +35,7 @@
       />
     Easily deploy and manage {{ chart.attributes.name }} in your
     Kubernetes cluster with Kubeapps.<br />
-    <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md" target="_blank">
+    <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md" target="_blank" rel="noopener">
       Get Started on GitHub
     </a>
   </div>

--- a/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
+++ b/src/app/chart-details/chart-details-usage/chart-details-usage.component.html
@@ -35,7 +35,7 @@
       />
     Easily deploy and manage {{ chart.attributes.name }} in your
     Kubernetes cluster with Kubeapps.<br />
-    <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md" >
+    <a href="https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md" target="_blank">
       Get Started on GitHub
     </a>
   </div>


### PR DESCRIPTION
Not sure it makes sense to direct people away from the Kubeapps Hub chart page, instead we can open the Kubeapps readme in a separate new window.

@earnubs what do you think?