### PR TITLE
switch to use auth endpoint mounted at /auth

### DIFF
--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -13,7 +13,6 @@ import { Http, Response } from '@angular/http';
 /* TODO, This is a mocked class. */
 @Injectable()
 export class AuthService {
-  hostname: string;
   user: any = {};
 
   constructor(
@@ -22,7 +21,6 @@ export class AuthService {
     private cookieService: CookieService,
     private router: Router,
   ) {
-    this.hostname = config.backendHostname;
   }
 
   /**
@@ -46,7 +44,7 @@ export class AuthService {
    * @return {Observable} An observable boolean that will be true if logged in or if auth is disabled
    */
   loggedIn(): Observable<boolean> {
-    return this.http.get(`${this.hostname}/auth/verify`, {withCredentials: true})
+    return this.http.get('/auth/verify', {withCredentials: true})
       .map((res: Response) => { return res.ok; })
       .catch(res => {
         if (res.status == 404) {
@@ -63,6 +61,6 @@ export class AuthService {
    */
   logout(): Observable<Response> {
     this.cookieService.remove('ka_claims');
-    return this.http.delete(`${this.hostname}/auth/logout`, {withCredentials: true});
+    return this.http.delete('/auth/logout', {withCredentials: true});
   }
 }


### PR DESCRIPTION
Previously, this would call auth endpoints on the old API server, which
is being removed. The /verify and /logout endpoints must be implemented
in the auth service mounted at /auth.

https://github.com/kubeapps/oauth2-bitnami/pull/4 implements this for
the oauth2-bitnami auth service used on https://hub.kubeapps.com.