### PR TITLE
re-adds ConfirmDialog to Angular's entryComponents

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -128,6 +128,7 @@ export function metaFactory(): MetaLoader {
     CommentsService,
   ],
   entryComponents: [
+    ConfirmDialog,
   ],
   bootstrap: [AppComponent]
 })


### PR DESCRIPTION
This was incorrectly removed, and causes the app the crash when opening
a dialog as it is not correctly registered. Can be reproduced by
attempting to delete a comment.