### PR TITLE
Add pagination

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -52,6 +52,8 @@ import { ConfirmDialog } from './confirm-dialog/confirm-dialog.component';
 import { ListItemComponent } from './list-item/list-item.component';
 import { ListFiltersComponent } from './list-filters/list-filters.component';
 import { TermsOfServiceComponent } from './terms-of-service/terms-of-service.component';
+import { PaginationComponent } from './pagination/pagination.component';
+import { PaginationItemComponent } from './pagination-item/pagination-item.component';
 
 import 'hammerjs';
 
@@ -90,6 +92,8 @@ export function metaFactory(): MetaLoader {
     ListFiltersComponent,
     ChartDetailsCommentsComponent,
     TermsOfServiceComponent,
+    PaginationComponent,
+    PaginationItemComponent
   ],
   imports: [
     MatIconModule,

--- a/src/app/chart-index/chart-index.component.html
+++ b/src/app/chart-index/chart-index.component.html
@@ -5,6 +5,7 @@
       <div class="chart-list">
         <app-chart-list [charts]="charts"></app-chart-list>
       </div>
+      <app-pagination [page]="page" [totalPages]="totalPages" [onSelect]="onSelect"></app-pagination>
     </app-loader>
   </app-panel>
 </section>

--- a/src/app/chart-index/chart-index.component.html
+++ b/src/app/chart-index/chart-index.component.html
@@ -1,4 +1,4 @@
-<app-main-header [totalChartsNumber]=totalChartsNumber></app-main-header>
+<app-main-header></app-main-header>
 <section class="chart-index__list">
   <app-panel>
     <app-loader [loading]="loading">

--- a/src/app/chart-index/chart-index.component.ts
+++ b/src/app/chart-index/chart-index.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
 import { SeoService } from '../shared/services/seo.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-chart-index',
@@ -9,9 +10,11 @@ import { SeoService } from '../shared/services/seo.service';
   styleUrls: ['./chart-index.component.scss']
 })
 export class ChartIndexComponent implements OnInit {
-	charts: Chart[]
+  charts: Chart[];
   loading: boolean = true;
-  totalChartsNumber: number
+  totalPages: number = 1;
+  page: number = 1;
+  onSelect = (page: number) => this.onSelectPage(page);
 
   constructor(
     private chartsService: ChartsService,
@@ -19,15 +22,21 @@ export class ChartIndexComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-		this.loadCharts();
+    this.loadCharts(this.page);
     this.seo.setMetaTags('index');
   }
 
-  loadCharts(): void {
-		this.chartsService.getCharts().subscribe(charts => {
+  loadCharts(page?: number): void {
+    this.chartsService.getCharts('all', page).subscribe(res => {
       this.loading = false;
-      this.charts = charts;
-      this.totalChartsNumber = charts.length;
+      this.charts = res.charts;
+      this.totalPages = res.meta.totalPages;
     });
+  }
+
+  onSelectPage(page: number) {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
   }
 }

--- a/src/app/chart-index/chart-index.component.ts
+++ b/src/app/chart-index/chart-index.component.ts
@@ -11,13 +11,8 @@ import { SeoService } from '../shared/services/seo.service';
 export class ChartIndexComponent implements OnInit {
   charts: Chart[];
   loading: boolean = true;
-  totalPages: number = 1;
+  totalPages: number = 0;
   page: number = 1;
-  onSelect = (page: number) => {
-    this.page = page;
-    this.loading = true;
-    this.loadCharts(page);
-  }
 
   constructor(
     private chartsService: ChartsService,
@@ -33,8 +28,13 @@ export class ChartIndexComponent implements OnInit {
     this.chartsService.getCharts('all', page).subscribe(res => {
       this.loading = false;
       this.charts = res.charts;
-      this.totalPages = res.meta.totalPages;
+      this.totalPages = res.meta && res.meta.totalPages;
     });
   }
 
+  onSelect = (page: number) => {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
+  }
 }

--- a/src/app/chart-index/chart-index.component.ts
+++ b/src/app/chart-index/chart-index.component.ts
@@ -13,7 +13,11 @@ export class ChartIndexComponent implements OnInit {
   loading: boolean = true;
   totalPages: number = 1;
   page: number = 1;
-  onSelect = (page: number) => this.onSelectPage(page);
+  onSelect = (page: number) => {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
+  }
 
   constructor(
     private chartsService: ChartsService,
@@ -33,9 +37,4 @@ export class ChartIndexComponent implements OnInit {
     });
   }
 
-  onSelectPage(page: number) {
-    this.page = page;
-    this.loading = true;
-    this.loadCharts(page);
-  }
 }

--- a/src/app/chart-index/chart-index.component.ts
+++ b/src/app/chart-index/chart-index.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { ChartsService } from '../shared/services/charts.service';
 import { Chart } from '../shared/models/chart';
 import { SeoService } from '../shared/services/seo.service';
-import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-chart-index',

--- a/src/app/chart-index/chart-index.component.ts
+++ b/src/app/chart-index/chart-index.component.ts
@@ -36,5 +36,5 @@ export class ChartIndexComponent implements OnInit {
     this.page = page;
     this.loading = true;
     this.loadCharts(page);
-  }
+  };
 }

--- a/src/app/charts/charts.component.html
+++ b/src/app/charts/charts.component.html
@@ -23,6 +23,7 @@
             <input type="text" placeholder="Search charts..." value="{{searchTerm}}" (keyup)="searchChange($event)" />
           </div>
           <app-chart-list [charts]="orderedCharts" [maxColumns]="3"></app-chart-list>
+          <app-pagination [page]="page" [totalPages]="totalPages" [onSelect]="onSelect"></app-pagination>
         </div>
       </div>
     </section>

--- a/src/app/charts/charts.component.ts
+++ b/src/app/charts/charts.component.ts
@@ -45,6 +45,10 @@ export class ChartsComponent implements OnInit {
   // Repos
   repoName: string;
 
+  totalPages: number = 1;
+  page: number = 1;
+  onSelect = (page: number) => this.onSelectPage(page);
+
   constructor(
     private chartsService: ChartsService,
     private reposService: ReposService,
@@ -82,10 +86,11 @@ export class ChartsComponent implements OnInit {
     });
   }
 
-  loadCharts(): void {
-    this.chartsService.getCharts(this.repoName).subscribe(charts => {
+  loadCharts(page?: number): void {
+    this.chartsService.getCharts(this.repoName, page).subscribe(res => {
       this.loading = false;
-      this.charts = charts;
+      this.charts = res.charts;
+      this.totalPages = res.meta.totalPages;
       if (!this.searchTerm) {
         this.orderedCharts = this.orderCharts(this.charts);
       }
@@ -129,7 +134,9 @@ export class ChartsComponent implements OnInit {
     this.searchTerm = e.target.value;
     clearTimeout(this.searchTimeout);
     if (!this.searchTerm) {
-      return (this.orderedCharts = this.orderCharts(this.charts));
+      // Reload state before search
+      this.loadCharts(this.page);
+      return;
     }
     this.searchTimeout = setTimeout(() => this.searchCharts(), 1000);
   }
@@ -144,6 +151,8 @@ export class ChartsComponent implements OnInit {
       .subscribe(charts => {
         this.loading = false;
         this.orderedCharts = this.orderCharts(charts);
+        // Remove pagination when doing a search
+        this.totalPages = 0;
       });
   }
 
@@ -184,5 +193,11 @@ export class ChartsComponent implements OnInit {
 
   capitalize(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+
+  onSelectPage(page: number) {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
   }
 }

--- a/src/app/charts/charts.component.ts
+++ b/src/app/charts/charts.component.ts
@@ -47,7 +47,11 @@ export class ChartsComponent implements OnInit {
 
   totalPages: number = 1;
   page: number = 1;
-  onSelect = (page: number) => this.onSelectPage(page);
+  onSelect = (page: number) => {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
+  }
 
   constructor(
     private chartsService: ChartsService,
@@ -82,7 +86,10 @@ export class ChartsComponent implements OnInit {
       this.repoName = params['repo'] ? params['repo'] : undefined;
       this.updateMetaTags();
       this.loadRepos();
-      this.loadCharts();
+      if (!this.searchTerm) {
+        // If we have already search some chart, don't reload
+        this.loadCharts();
+      }
     });
   }
 
@@ -193,11 +200,5 @@ export class ChartsComponent implements OnInit {
 
   capitalize(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
-  }
-
-  onSelectPage(page: number) {
-    this.page = page;
-    this.loading = true;
-    this.loadCharts(page);
   }
 }

--- a/src/app/charts/charts.component.ts
+++ b/src/app/charts/charts.component.ts
@@ -45,13 +45,8 @@ export class ChartsComponent implements OnInit {
   // Repos
   repoName: string;
 
-  totalPages: number = 1;
+  totalPages: number = 0;
   page: number = 1;
-  onSelect = (page: number) => {
-    this.page = page;
-    this.loading = true;
-    this.loadCharts(page);
-  }
 
   constructor(
     private chartsService: ChartsService,
@@ -97,7 +92,7 @@ export class ChartsComponent implements OnInit {
     this.chartsService.getCharts(this.repoName, page).subscribe(res => {
       this.loading = false;
       this.charts = res.charts;
-      this.totalPages = res.meta.totalPages;
+      this.totalPages = res.meta && res.meta.totalPages;
       if (!this.searchTerm) {
         this.orderedCharts = this.orderCharts(this.charts);
       }
@@ -200,5 +195,11 @@ export class ChartsComponent implements OnInit {
 
   capitalize(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+
+  onSelect = (page: number) => {
+    this.page = page;
+    this.loading = true;
+    this.loadCharts(page);
   }
 }

--- a/src/app/main-header/main-header.component.html
+++ b/src/app/main-header/main-header.component.html
@@ -12,9 +12,6 @@
           <label for="searchBox">Search charts</label>
           <input id="searchBox" placeholder="WordPress, Jenkins, Kubeless..." #searchBox />
         </form>
-        <p class="main-header-search__summary type-tiny margin-reset text-c" *ngIf="totalChartsNumber">
-          <b>{{ totalChartsNumber }}</b> charts ready to deploy
-        </p>
       </div>
     </div>
   </div>

--- a/src/app/main-header/main-header.component.ts
+++ b/src/app/main-header/main-header.component.ts
@@ -8,7 +8,6 @@ import { Router, NavigationExtras } from '@angular/router';
   encapsulation: ViewEncapsulation.None
 })
 export class MainHeaderComponent implements OnInit {
-  @Input() totalChartsNumber: number
   // Store the router
   constructor(private router: Router) { }
   ngOnInit() { }

--- a/src/app/pagination-item/pagination-item.component.html
+++ b/src/app/pagination-item/pagination-item.component.html
@@ -1,0 +1,4 @@
+<li *ngIf=current class="pagination__current">
+  <a aria-current="true" (click)='onSelect(page)'>{{page}}</a>
+</li>
+<li *ngIf="!current" (click)='onSelect(page)'><a >{{page}}</a></li>

--- a/src/app/pagination-item/pagination-item.component.html
+++ b/src/app/pagination-item/pagination-item.component.html
@@ -1,4 +1,3 @@
-<li *ngIf=current class="pagination__current">
-  <a aria-current="true" (click)='onSelect(page)'>{{page}}</a>
+<li [ngClass]="{'pagination__current': current}" (click)='onSelect(page)'>
+  <a [attr.aria-current]="current ? 'true' : null">{{page}}</a>
 </li>
-<li *ngIf="!current" (click)='onSelect(page)'><a >{{page}}</a></li>

--- a/src/app/pagination-item/pagination-item.component.ts
+++ b/src/app/pagination-item/pagination-item.component.ts
@@ -4,7 +4,7 @@ import { Component, Input } from '@angular/core';
   templateUrl: './pagination-item.component.html'
 })
 export class PaginationItemComponent {
-  @Input() page: string;
+  @Input() page: number;
   @Input() current: boolean;
   @Input() onSelect: (page: string) => void;
 }

--- a/src/app/pagination-item/pagination-item.component.ts
+++ b/src/app/pagination-item/pagination-item.component.ts
@@ -4,7 +4,7 @@ import { Component, Input } from '@angular/core';
   templateUrl: './pagination-item.component.html'
 })
 export class PaginationItemComponent {
-  @Input() page: number;
+  @Input() page: string;
   @Input() current: boolean;
   @Input() onSelect: (page: string) => void;
 }

--- a/src/app/pagination-item/pagination-item.component.ts
+++ b/src/app/pagination-item/pagination-item.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+@Component({
+  selector: 'app-pagination-item',
+  templateUrl: './pagination-item.component.html'
+})
+export class PaginationItemComponent {
+  @Input() page: string;
+  @Input() current: boolean;
+  @Input() onSelect: (page: string) => void;
+}

--- a/src/app/pagination/pagination.component.html
+++ b/src/app/pagination/pagination.component.html
@@ -1,0 +1,5 @@
+<nav class="pagination" role="navigation" aria-label="Pagination Navigation">
+  <ul>
+    <app-pagination-item *ngFor="let p of pages" [page]=p [current]="page == p" [onSelect]="onSelect"></app-pagination-item>
+  </ul>
+</nav>

--- a/src/app/pagination/pagination.component.ts
+++ b/src/app/pagination/pagination.component.ts
@@ -1,25 +1,32 @@
-import { Component, Input, OnChanges, SimpleChanges, SimpleChange } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, SimpleChange } from '@angular/core';
 
 @Component({
   selector: 'app-pagination',
   templateUrl: './pagination.component.html'
 })
-export class PaginationComponent implements OnChanges {
+export class PaginationComponent implements OnInit, OnChanges {
   @Input() totalPages: number;
   @Input() page: number;
   @Input() onSelect: (page: string) => void;
-  get pages(): number[] {
-    const pages = [];
-    for (let i = 1; i <= this.totalPages; i++) {
-      pages.push(i.toString());
-    }
-    return pages;
+  pages: number[];
+
+  ngOnInit()  {
+    this.getPages();
   }
 
   ngOnChanges(changes: SimpleChanges) {
     const totalPages: SimpleChange = changes.totalPages;
     if (totalPages) {
       this.totalPages = totalPages.currentValue;
+      this.getPages();
     }
+  }
+
+  getPages() {
+    this.pages = [];
+    for (let i = 1; i <= this.totalPages; i++) {
+      this.pages.push(i);
+    }
+    return this.pages;
   }
 }

--- a/src/app/pagination/pagination.component.ts
+++ b/src/app/pagination/pagination.component.ts
@@ -5,12 +5,12 @@ import { Component, Input, OnChanges, SimpleChanges, SimpleChange } from '@angul
   templateUrl: './pagination.component.html'
 })
 export class PaginationComponent implements OnChanges {
-  @Input() totalPages: string;
-  @Input() page: string;
+  @Input() totalPages: number;
+  @Input() page: number;
   @Input() onSelect: (page: string) => void;
-  get pages(): string[] {
+  get pages(): number[] {
     const pages = [];
-    for (let i = 1; i <= parseInt(this.totalPages, 10); i++) {
+    for (let i = 1; i <= this.totalPages; i++) {
       pages.push(i.toString());
     }
     return pages;

--- a/src/app/pagination/pagination.component.ts
+++ b/src/app/pagination/pagination.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, OnChanges, SimpleChanges, SimpleChange } from '@angular/core';
+
+@Component({
+  selector: 'app-pagination',
+  templateUrl: './pagination.component.html'
+})
+export class PaginationComponent implements OnChanges {
+  @Input() totalPages: string;
+  @Input() page: string;
+  @Input() onSelect: (page: string) => void;
+  get pages(): string[] {
+    const pages = [];
+    for (let i = 1; i <= parseInt(this.totalPages, 10); i++) {
+      pages.push(i.toString());
+    }
+    return pages;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const totalPages: SimpleChange = changes.totalPages;
+    if (totalPages) {
+      this.totalPages = totalPages.currentValue;
+    }
+  }
+}

--- a/src/app/shared/services/charts.service.ts
+++ b/src/app/shared/services/charts.service.ts
@@ -14,7 +14,7 @@ import { Http, Response } from '@angular/http';
 @Injectable()
 export class ChartsService {
   hostname: string;
-  cacheCharts: {[repo: string]: {charts: Chart[], meta: any}};
+  cacheCharts: {[key: string]: {charts: Chart[], meta: any}};
 
   constructor(
     private http: Http,
@@ -139,7 +139,7 @@ export class ChartsService {
    * @param {Chart[]} data Elements in the response
    * @return {Chart[]} Return the same response
    */
-  private storeCache(data: {charts: Chart[], meta: any}, key: string): {charts: Chart[], meta?: any} {
+  private storeCache(data: {charts: Chart[], meta: any}, key: string): {charts: Chart[], meta: any} {
     this.cacheCharts[key] = data;
     return data;
   }

--- a/src/app/shared/services/charts.service.ts
+++ b/src/app/shared/services/charts.service.ts
@@ -69,8 +69,8 @@ export class ChartsService {
 
   searchCharts(query, repo?: string): Observable<Chart[]> {
     const url = repo ?
-      `${this.hostname}/v1/charts/${repo}/search?match=${query}` :
-      `${this.hostname}/v1/charts/search?match=${query}`;
+      `${this.hostname}/v1/charts/${repo}/search?q=${query}` :
+      `${this.hostname}/v1/charts/search?q=${query}`;
     const cacheKey = `${repo}/${query}`;
     return this.requestCharts(url, cacheKey).map(res => res.charts);
   }


### PR DESCRIPTION
Requires changes in the chartsvc.

![opengl-rotating-triangle](https://user-images.githubusercontent.com/4025665/53968820-00bd8c00-40f8-11e9-8fb3-244b9c716c21.gif)

Known issues:

 - I had to remove the info `{{totalChartsNumber}} charts ready to deploy` since we no longer have all the charts in the front end.
 - When doing a search we are not paginating the result so if a search returns many results all of them will be shown.
 - It's not possible to go to a certain page using an URL (i.e. hub.kubeapps.com/?page=3)
 - When changing the page, if the charts are already cached, the browser don't go to the top of the page so users need to scroll up